### PR TITLE
Bump Monolog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 vendor
+.idea
 coverage
 api
 phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ branches:
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
   - nightly
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ About
 Requirements
 ------------
 
-- From PHP 7.1 and above
+- From PHP 7.2 and above
 - PHPUnit 7.4 or higher for test suite execution
 
 Bugs and feature requests

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "monolog/monolog": "^1.24",
+        "monolog/monolog": "^2.0",
         "ext-curl": "*"
     },
     "require-dev": {

--- a/tests/Vatsimphp/Log/LoggerTest.php
+++ b/tests/Vatsimphp/Log/LoggerTest.php
@@ -62,6 +62,6 @@ class LoggerTest extends TestCase
             ->setMethods(null)
             ->getMock();
         $this->assertEquals('foo', $logger->getName());
-        $this->assertTrue($logger->critical('logthis'));
+        $this->assertNull($logger->critical('logthis'));
     }
 }


### PR DESCRIPTION
This PR bumps Monolog from v1 to v2. The main aim of this was to ensure compatibility with Laravel 7 and above.

Change Log: https://github.com/Seldaek/monolog/blob/master/CHANGELOG.md
Upgrade Guide: https://github.com/Seldaek/monolog/blob/master/UPGRADE.md

Only one change appears to have been breaking for this app.

```
BC Break: Logger methods log/debug/info/notice/warning/error/critical/alert/emergency now have explicit void return types
```