### PR TITLE
Fix legacy date format which was broken by switching to v3 data feed

### DIFF
--- a/tests/Vatsimphp/Parser/DataParserTest.php
+++ b/tests/Vatsimphp/Parser/DataParserTest.php
@@ -69,7 +69,7 @@ class DataParserTest extends TestCase
             // test actual data
             $rs = $class->getParsedData();
             foreach ($expectedData as $section => $values) {
-                $this->assertSame($values, array_values($rs->$section->toArray()));
+                $this->assertEquals($values, array_values($rs->$section->toArray()));
             }
         }
     }
@@ -77,49 +77,190 @@ class DataParserTest extends TestCase
     public function providerTestParseData()
     {
         $general = "!GENERAL:\n";
-        $general .= "VERSION = 1\nRELOAD = 2\nUPDATE = 19990601000000\n";
-        $general .= "ATIS ALLOW MIN = 5\nCONNECTED CLIENTS = 1";
+        $general .= "VERSION = 1\nRELOAD = 2\nUPDATE = 20210101223245\n";
+        $general .= "ATIS ALLOW MIN = 5\nCONNECTED CLIENTS = 649\nUNIQUE USERS = 622\n";
 
         $generalInvalid = "!GENERAL:\n";
-        $generalInvalid .= "VERSION = 1\nRELOAD\n";
-        $generalInvalid .= "ATIS ALLOW MIN = 5\nCONNECTED CLIENTS = 1";
 
-        $clientsHead = "\n; !CLIENTS section -         callsign:cid:realname:\n";
+        $clientsHead = "; !CLIENTS section - callsign:cid:realname:clienttype:frequency:latitude:longitude:altitude:groundspeed:planned_aircraft:planned_tascruise:planned_depairport:planned_altitude:planned_destairport:server:protrevision:rating:transponder:facilitytype:visualrange:planned_revision:planned_flighttype:planned_deptime:planned_actdeptime:planned_hrsenroute:planned_minenroute:planned_hrsfuel:planned_minfuel:planned_altairport:planned_remarks:planned_route:planned_depairport_lat:planned_depairport_lon:planned_destairport_lat:planned_destairport_lon:atis_message:time_last_atis_received:time_logon:heading:QNH_iHg:QNH_Mb:\n";
         $clients = "!CLIENTS:\n";
-        $clients .= 'SWA3437:123456:Jelle Vink KSJC:';
+        $clients .= "SWA3437:1234567:John Doe:PILOT::34.57682:-116.04695:29273:467:H/CONC/L:483:KORD:50000:KLAX:USA-WEST:100:1:3262:0:0:4:I:0:0:0:0:0:0:KONT:A/C Type  Concorde.  RNAV and RVSM equipped. /v/:+PEKUE PIPPN ROTTN PWE J64 TBC JASSE Q90 DNERO ANJLL4:0:0:0:0::20210101201013:20210101201013:253:30.18:1022:\n";
+        $clients .= "KBOS_ATIS:7654321:John Foe:ATC:135.000:42.36296:-71.00643:0:0::::::USA-WEST:100:3:0:4:50::::::::::::0:0:0:0:BOSTON LOGAN AIRPORT ATIS INFORMATION Z. 2254Z. 15005KT 10SM FEW120 BKN160 OVC250 01/-03 A3040. ILS RWY 22L APCH IN USE, DEPTG RWY 22R.:20210101202838:20210101202838:0:0:0:\n";
 
-        $voiceHead = "\n; !VOICE SERVERS section -   hostname_or_IP:location:\n";
-        $voice = "!VOICE SERVERS:\n";
-        $voice .= 'rw.liveatc.net:North America, USA, California:';
+        $prefile = "!PREFILE:\n";
+        $prefile .= "SWA3438:11223344556677:Jane Doe:::0:0:0:0:A21N/L:449:KCLT:37000:KBOS::0:0:0:0:0:3:I:2035:2035:1:29:3:36:KJFK:SEL/FMLP PER/C TALT/KATL RMK/TCAS /V/:BARMY4 RDU THHMP OOD J42 RBV J222 JFK ROBUC3:0:0:0:0::00010101000000:00010101000000:0:0:0:\n";
+
+        $serversHead = "; !VOICE SERVERS section -   hostname_or_IP:location:\n";
+        $servers = "!SERVERS:\n";
+        $servers .= "CANADA:165.22.239.218:Toronto, Canada:CANADA:1:\n";
 
         // valid (normal) data
-        $validData = $general.$clientsHead.$clients.$voiceHead.$voice;
+        $validData1 = $general.$clientsHead.$clients.$prefile.$serversHead.$servers;
+
+        // valid without voice head
+        $validData2 = $general.$clientsHead.$clients.$prefile.$servers;
+
+        $expectedValidData = [
+            'clients' => [
+                [
+                    'callsign' => 'SWA3437',
+                    'cid'      => '1234567',
+                    'realname' => 'John Doe',
+                    'clienttype' => 'PILOT',
+                    'frequency' => '',
+                    'latitude' => '34.57682',
+                    'longitude' => '-116.04695',
+                    'altitude' => '29273',
+                    'groundspeed' => '467',
+                    'planned_aircraft' => 'H/CONC/L',
+                    'planned_tascruise' => '483',
+                    'planned_depairport' => 'KORD',
+                    'planned_altitude' => '50000',
+                    'planned_destairport' => 'KLAX',
+                    'server' => 'USA-WEST',
+                    'protrevision' => '100',
+                    'rating' => '1',
+                    'transponder' => '3262',
+                    'facilitytype' => '0',
+                    'visualrange' => '0',
+                    'planned_revision' => '4',
+                    'planned_flighttype' => 'I',
+                    'planned_deptime' => '0',
+                    'planned_actdeptime' => '0',
+                    'planned_hrsenroute' => '0',
+                    'planned_minenroute' => '0',
+                    'planned_hrsfuel' => '0',
+                    'planned_minfuel' => '0',
+                    'planned_altairport' => 'KONT',
+                    'planned_remarks' => 'A/C Type  Concorde.  RNAV and RVSM equipped. /v/',
+                    'planned_route' => '+PEKUE PIPPN ROTTN PWE J64 TBC JASSE Q90 DNERO ANJLL4',
+                    'planned_depairport_lat' => '0',
+                    'planned_depairport_lon' => '0',
+                    'planned_destairport_lat' => '0',
+                    'planned_destairport_lon' => '0',
+                    'atis_message' => '',
+                    'time_last_atis_received' => '20210101201013',
+                    'time_logon' => '20210101201013',
+                    'heading' => '253',
+                    'QNH_iHg' => '30.18',
+                    'QNH_Mb' => '1022',
+                ],
+                [
+                    'callsign' => 'KBOS_ATIS',
+                    'cid' => '7654321',
+                    'realname' => 'John Foe',
+                    'clienttype' => 'ATC',
+                    'frequency' => '135.000',
+                    'latitude' => '42.36296',
+                    'longitude' => '-71.00643',
+                    'altitude' => '0',
+                    'groundspeed' => '0',
+                    'planned_aircraft' => '',
+                    'planned_tascruise' => '',
+                    'planned_depairport' => '',
+                    'planned_altitude' => '',
+                    'planned_destairport' => '',
+                    'server' => 'USA-WEST',
+                    'protrevision' => '100',
+                    'rating' => '3',
+                    'transponder' => '0',
+                    'facilitytype' => '4',
+                    'visualrange' => '50',
+                    'planned_revision' => '',
+                    'planned_flighttype' => '',
+                    'planned_deptime' => '',
+                    'planned_actdeptime' => '',
+                    'planned_hrsenroute' => '',
+                    'planned_minenroute' => '',
+                    'planned_hrsfuel' => '',
+                    'planned_minfuel' => '',
+                    'planned_altairport' => '',
+                    'planned_remarks' => '',
+                    'planned_route' => '',
+                    'planned_depairport_lat' => '0',
+                    'planned_depairport_lon' => '0',
+                    'planned_destairport_lat' => '0',
+                    'planned_destairport_lon' => '0',
+                    'atis_message' => 'BOSTON LOGAN AIRPORT ATIS INFORMATION Z. 2254Z. 15005KT 10SM FEW120 BKN160 OVC250 01/-03 A3040. ILS RWY 22L APCH IN USE, DEPTG RWY 22R.',
+                    'time_last_atis_received' => '20210101202838',
+                    'time_logon' => '20210101202838',
+                    'heading' => '0',
+                    'QNH_iHg' => '0',
+                    'QNH_Mb' => '0',
+                ],
+            ],
+            'prefile' => [
+                [
+                    'callsign' => 'SWA3438',
+                    'cid' => '11223344556677',
+                    'realname' => 'Jane Doe',
+                    'clienttype' => '',
+                    'frequency' => '',
+                    'latitude' => '0',
+                    'longitude' => '0',
+                    'altitude' => '0',
+                    'groundspeed' => '0',
+                    'planned_aircraft' => 'A21N/L',
+                    'planned_tascruise' => '449',
+                    'planned_depairport' => 'KCLT',
+                    'planned_altitude' => '37000',
+                    'planned_destairport' => 'KBOS',
+                    'server' => '',
+                    'protrevision' => '0',
+                    'rating' => '0',
+                    'transponder' => '0',
+                    'facilitytype' => '0',
+                    'visualrange' => '0',
+                    'planned_revision' => '3',
+                    'planned_flighttype' => 'I',
+                    'planned_deptime' => '2035',
+                    'planned_actdeptime' => '2035',
+                    'planned_hrsenroute' => '1',
+                    'planned_minenroute' => '29',
+                    'planned_hrsfuel' => '3',
+                    'planned_minfuel' => '36',
+                    'planned_altairport' => 'KJFK',
+                    'planned_remarks' => 'SEL/FMLP PER/C TALT/KATL RMK/TCAS /V/',
+                    'planned_route' => 'BARMY4 RDU THHMP OOD J42 RBV J222 JFK ROBUC3',
+                    'planned_depairport_lat' => '0',
+                    'planned_depairport_lon' => '0',
+                    'planned_destairport_lat' => '0',
+                    'planned_destairport_lon' => '0',
+                    'atis_message' => '',
+                    'time_last_atis_received' => '00010101000000',
+                    'time_logon' => '00010101000000',
+                    'heading' => '0',
+                    'QNH_iHg' => '0',
+                    'QNH_Mb' => '0',
+                ],
+            ],
+            'servers' => [
+                [
+                    'ident' => 'CANADA',
+                    'hostname_or_IP' => '165.22.239.218',
+                    'location' => 'Toronto, Canada',
+                    'name' => 'CANADA',
+                    'clients_connection_allowed' => '1',
+                ],
+            ],
+        ];
 
         // without general section
-        $invalidData1 = $clientsHead.$clients.$voiceHead.$voice;
+        $invalidData1 = $clientsHead.$clients.$serversHead.$servers;
 
         // with invalid general section
-        $invalidData2 = $generalInvalid.$clientsHead.$clients.$voiceHead.$voice;
+        $invalidData2 = $generalInvalid.$clientsHead.$clients.$serversHead.$servers;
 
         return [
             [
-                $validData,
+                $validData1,
                 true,
-                [
-                    'clients' => [
-                        [
-                            'callsign' => 'SWA3437',
-                            'cid'      => '123456',
-                            'realname' => 'Jelle Vink KSJC',
-                        ],
-                    ],
-                    'voice_servers' => [
-                        [
-                            'hostname_or_IP' => 'rw.liveatc.net',
-                            'location'       => 'North America, USA, California',
-                        ],
-                    ],
-                ],
+                $expectedValidData,
+            ],
+            [
+                $validData2,
+                true,
+                $expectedValidData,
             ],
             [
                 $invalidData1,
@@ -132,7 +273,7 @@ class DataParserTest extends TestCase
                 [],
             ],
             [
-                $validData,
+                $validData1,
                 false,
                 [],
                 300,

--- a/tests/Vatsimphp/Parser/DataV3CompatParserTest.php
+++ b/tests/Vatsimphp/Parser/DataV3CompatParserTest.php
@@ -66,7 +66,7 @@ class DataV3CompatParserTest extends TestCase
             // test actual data
             $rs = $class->getParsedData();
             foreach ($expectedData as $section => $values) {
-                $this->assertSame($values, array_values($rs->$section->toArray()));
+                $this->assertEqualsArray($values, array_values($rs->$section->toArray()));
             }
         }
     }
@@ -78,33 +78,239 @@ class DataV3CompatParserTest extends TestCase
             "general": {
                 "version": 3,
                 "reload": 1,
-                "update": "20201227085129",
-                "update_timestamp": "2020-12-27T08:51:29.2145727Z",
+                "update": "20210101223245",
+                "update_timestamp": "2021-01-01T22:32:45.2145727Z",
                 "connected_clients": 649,
                 "unique_users": 622
             },
             "pilots": [
                 {
-                    "cid": 123456,
-                    "name": "Jelle Vink KSJC",
-                    "callsign": "SWA3437"
+                    "cid": 1234567,
+                    "name": "John Doe",
+                    "callsign": "SWA3437",
+                    "server": "USA-WEST",
+                    "pilot_rating": 1,
+                    "latitude": 34.57682,
+                    "longitude": -116.04695,
+                    "altitude": 29273,
+                    "groundspeed": 467,
+                    "transponder": "3262",
+                    "heading": 253,
+                    "qnh_i_hg": 30.18,
+                    "qnh_mb": 1022,
+                    "flight_plan":{
+                        "flight_rules": "I",
+                        "aircraft": "H/CONC/L",
+                        "departure": "KORD",
+                        "arrival": "KLAX",
+                        "alternate": "KONT",
+                        "cruise_tas": "483",
+                        "altitude": "50000",
+                        "deptime": "0",
+                        "enroute_time": "0",
+                        "fuel_time": "0",
+                        "remarks": "A/C Type  Concorde.  RNAV and RVSM equipped. /v/",
+                        "route": "+PEKUE PIPPN ROTTN PWE J64 TBC JASSE Q90 DNERO ANJLL4"
+                    },
+                    "logon_time":"2021-01-01T20:10:13.1294438Z",
+                    "last_updated":"2021-01-02T00:17:15.664797Z"
                 }
             ],
             "controllers": [
                 {
-                    "cid": 654321,
-                    "name": "John Doe",
-                    "callsign": "CPA676"
+                    "cid": 7654321,
+                    "name": "John Foe",
+                    "callsign": "KBOS_ATIS",
+                    "frequency": "135.000",
+                    "facility": 4,
+                    "rating": 3,
+                    "server": "USA-WEST",
+                    "visual_range": 50,
+                    "text_atis":[
+                        "BOSTON LOGAN AIRPORT ATIS INFORMATION Z. 2254Z. 15005KT 10SM",
+                        "FEW120 BKN160 OVC250 01/-03 A3040. ILS RWY 22L APCH IN USE, DEPTG RWY 22R."
+                    ],
+                    "last_updated":"2021-01-02T20:28:38.2242002Z",
+                    "logon_time":"2021-01-01T20:28:38.1658435Z"
+                }
+            ],
+            "prefiles": [
+                {
+                    "cid": 11223344556677,
+                    "name": "Jane Doe",
+                    "callsign": "SWA3438",
+                    "flight_plan":{
+                        "flight_rules": "I",
+                        "aircraft": "A21N/L",
+                        "departure":"KCLT",
+                        "arrival": "KBOS",
+                        "alternate": "KJFK",
+                        "cruise_tas": "449",
+                        "altitude": "37000",
+                        "deptime": "2035",
+                        "enroute_time": "0129",
+                        "fuel_time": "0336",
+                        "remarks": "SEL/FMLP PER/C TALT/KATL RMK/TCAS /V/",
+                        "route": "BARMY4 RDU THHMP OOD J42 RBV J222 JFK ROBUC3"
+                    },
+                    "last_updated": "2021-01-01T21:26:52.3657456Z"
                 }
             ],
             "servers": [
                 {
                     "ident": "CANADA",
-                    "hostname_or_ip": "1.2.3.4",
-                    "location": "Toronto, Canada"
+                    "hostname_or_ip": "165.22.239.218",
+                    "location": "Toronto, Canada",
+                    "name": "CANADA",
+                    "clients_connection_allowed": 1
                 }
             ]
         }';
+
+        $expectedValidData = [
+            'clients' => [
+                [
+                    'callsign' => 'SWA3437',
+                    'cid'      => '1234567',
+                    'realname' => 'John Doe',
+                    'clienttype' => 'PILOT',
+                    //'frequency' => '',
+                    'latitude' => '34.57682',
+                    'longitude' => '-116.04695',
+                    'altitude' => '29273',
+                    'groundspeed' => '467',
+                    'planned_aircraft' => 'H/CONC/L',
+                    'planned_tascruise' => '483',
+                    'planned_depairport' => 'KORD',
+                    'planned_altitude' => '50000',
+                    'planned_destairport' => 'KLAX',
+                    'server' => 'USA-WEST',
+                    //'protrevision' => '100',
+                    'rating' => '1',
+                    'transponder' => '3262',
+                    //'facilitytype' => '0',
+                    //'visualrange' => '0',
+                    //'planned_revision' => '4',
+                    'planned_flighttype' => 'I',
+                    'planned_deptime' => '0',
+                    //'planned_actdeptime' => '0',
+                    'planned_hrsenroute' => '0',
+                    //'planned_minenroute' => '0',
+                    'planned_hrsfuel' => '0',
+                    //'planned_minfuel' => '0',
+                    'planned_altairport' => 'KONT',
+                    'planned_remarks' => 'A/C Type  Concorde.  RNAV and RVSM equipped. /v/',
+                    'planned_route' => '+PEKUE PIPPN ROTTN PWE J64 TBC JASSE Q90 DNERO ANJLL4',
+                    //'planned_depairport_lat' => '0',
+                    //'planned_depairport_lon' => '0',
+                    //'planned_destairport_lat' => '0',
+                    //'planned_destairport_lon' => '0',
+                    //'atis_message' => '',
+                    //'time_last_atis_received' => '20210101201013',
+                    'time_logon' => '20210101201013',
+                    'heading' => '253',
+                    'QNH_iHg' => '30.18',
+                    'QNH_Mb' => '1022',
+                ],
+                [
+                    'callsign' => 'KBOS_ATIS',
+                    'cid' => '7654321',
+                    'realname' => 'John Foe',
+                    'clienttype' => 'ATC',
+                    'frequency' => '135.000',
+                    //'latitude' => '42.36296',
+                    //'longitude' => '-71.00643',
+                    //'altitude' => '0',
+                    //'groundspeed' => '0',
+                    //'planned_aircraft' => '',
+                    //'planned_tascruise' => '',
+                    //'planned_depairport' => '',
+                    //'planned_altitude' => '',
+                    //'planned_destairport' => '',
+                    'server' => 'USA-WEST',
+                    //'protrevision' => '100',
+                    'rating' => '3',
+                    //'transponder' => '0',
+                    'facilitytype' => '4',
+                    'visualrange' => '50',
+                    //'planned_revision' => '',
+                    //'planned_flighttype' => '',
+                    //'planned_deptime' => '',
+                    //'planned_actdeptime' => '',
+                    //'planned_hrsenroute' => '',
+                    //'planned_minenroute' => '',
+                    //'planned_hrsfuel' => '',
+                    //'planned_minfuel' => '',
+                    //'planned_altairport' => '',
+                    //'planned_remarks' => '',
+                    //'planned_route' => '',
+                    //'planned_depairport_lat' => '0',
+                    //'planned_depairport_lon' => '0',
+                    //'planned_destairport_lat' => '0',
+                    //'planned_destairport_lon' => '0',
+                    'atis_message' => 'BOSTON LOGAN AIRPORT ATIS INFORMATION Z. 2254Z. 15005KT 10SM FEW120 BKN160 OVC250 01/-03 A3040. ILS RWY 22L APCH IN USE, DEPTG RWY 22R.',
+                    //'time_last_atis_received' => '20210101202838',
+                    'time_logon' => '20210101202838',
+                    //'heading' => '0',
+                    //'QNH_iHg' => '0',
+                    //'QNH_Mb' => '0',
+                ],
+            ],
+            'prefile' => [
+                [
+                    'callsign' => 'SWA3438',
+                    'cid' => '11223344556677',
+                    'realname' => 'Jane Doe',
+                    //'clienttype' => '',
+                    //'frequency' => '',
+                    //'latitude' => '0',
+                    //'longitude' => '0',
+                    //'altitude' => '0',
+                    //'groundspeed' => '0',
+                    'planned_aircraft' => 'A21N/L',
+                    'planned_tascruise' => '449',
+                    'planned_depairport' => 'KCLT',
+                    'planned_altitude' => '37000',
+                    'planned_destairport' => 'KBOS',
+                    //'server' => '',
+                    //'protrevision' => '0',
+                    //'rating' => '0',
+                    //'transponder' => '0',
+                    //'facilitytype' => '0',
+                    //'visualrange' => '0',
+                    //'planned_revision' => '3',
+                    'planned_flighttype' => 'I',
+                    'planned_deptime' => '2035',
+                    //'planned_actdeptime' => '2035',
+                    'planned_hrsenroute' => '0129', // needs parsing
+                    //'planned_minenroute' => '29',
+                    'planned_hrsfuel' => '0336', // needs parsing
+                    //'planned_minfuel' => '36',
+                    'planned_altairport' => 'KJFK',
+                    'planned_remarks' => 'SEL/FMLP PER/C TALT/KATL RMK/TCAS /V/',
+                    'planned_route' => 'BARMY4 RDU THHMP OOD J42 RBV J222 JFK ROBUC3',
+                    //'planned_depairport_lat' => '0',
+                    //'planned_depairport_lon' => '0',
+                    //'planned_destairport_lat' => '0',
+                    //'planned_destairport_lon' => '0',
+                    // 'atis_message' => '',
+                    //'time_last_atis_received' => '00010101000000',
+                    //'time_logon' => '00010101000000',
+                    //'heading' => '0',
+                    //'QNH_iHg' => '0',
+                    //'QNH_Mb' => '0',
+                ],
+            ],
+            'servers' => [
+                [
+                    'ident' => 'CANADA',
+                    'hostname_or_IP' => '165.22.239.218',
+                    'location' => 'Toronto, Canada',
+                    'name' => 'CANADA',
+                    'clients_connection_allowed' => '1',
+                ],
+            ],
+        ];
 
         // without general section
         $invalidData1 = '{
@@ -135,29 +341,7 @@ class DataV3CompatParserTest extends TestCase
             [
                 $validData,
                 true,
-                [
-                    'clients' => [
-                        [
-                            'callsign' => 'SWA3437',
-                            'cid'      => '123456',
-                            'realname' => 'Jelle Vink KSJC',
-                            'clienttype' => 'PILOT',
-                        ],
-                        [
-                            'callsign' => 'CPA676',
-                            'cid'      => '654321',
-                            'realname' => 'John Doe',
-                            'clienttype' => 'ATC',
-                        ],
-                    ],
-                    'servers' => [
-                        [
-                            'ident' => 'CANADA',
-                            'hostname_or_IP' => '1.2.3.4',
-                            'location'       => 'Toronto, Canada',
-                        ],
-                    ],
-                ],
+                $expectedValidData,
             ],
             [
                 $invalidData1,
@@ -183,5 +367,14 @@ class DataV3CompatParserTest extends TestCase
             ->getMock();
 
         return $class;
+    }
+
+    /**
+     * Helper comparing to keyed arrays.
+     */
+    protected function assertEqualsArray($exp, $act) {
+        ksort($exp);
+        ksort($act);
+        $this->assertEquals($exp, $act);
     }
 }


### PR DESCRIPTION
Expand data unit testing including all available fields. This commit 
primarily aims solving the legacy date format. Additional fields have
been identified no passing proper from v3 into the legacy format.

This minor discrepancies may be solved later in this release. Regardless
the new v3 will bring pure objects to the table which makes the
processing less daunting as per the new OpenAPI contract.

Fixes #35 