### PR TITLE
fix: Fix return type declarations for PHP 8 compatibility

### DIFF
--- a/src/Vatsimphp/Filter/AbstractFilter.php
+++ b/src/Vatsimphp/Filter/AbstractFilter.php
@@ -95,7 +95,7 @@ abstract class AbstractFilter extends FilterIterator implements FilterInterface,
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->toArray());
     }
@@ -105,7 +105,7 @@ abstract class AbstractFilter extends FilterIterator implements FilterInterface,
      *
      * @return bool
      */
-    final public function accept()
+    final public function accept(): bool
     {
         // skip comments and empty lines
         $line = $this->getInnerIterator()->current();
@@ -119,7 +119,7 @@ abstract class AbstractFilter extends FilterIterator implements FilterInterface,
     /**
      * @see FilterIterator::current()
      */
-    public function current()
+    public function current(): mixed
     {
         $value = parent::current();
         if (is_string($value)) {

--- a/src/Vatsimphp/Filter/VarFilter.php
+++ b/src/Vatsimphp/Filter/VarFilter.php
@@ -40,7 +40,7 @@ class VarFilter extends StartOfLineFilter
     /**
      * @see Vatsimphp\Filter.AbstractFilter::current()
      */
-    public function current()
+    public function current(): mixed
     {
         $value = parent::current();
 

--- a/src/Vatsimphp/Result/ResultContainer.php
+++ b/src/Vatsimphp/Result/ResultContainer.php
@@ -39,9 +39,7 @@ class ResultContainer implements \Countable
     /**
      * Ctor.
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     /**
      * Append/overwrite a new result set.
@@ -99,7 +97,7 @@ class ResultContainer implements \Countable
     /**
      * @see Countable::count()
      */
-    public function count()
+    public function count(): int
     {
         return count($this->container);
     }


### PR DESCRIPTION
- Updated return types in `ResultContainer` , `AbstractFilter`  and `VarFilter` to comply with PHP 8 requirements.
- Fixed deprecation notices related to `Countable::count()` , `FilterIterator::accept()` and `FilterIterator::current()`.